### PR TITLE
Recover cab calls on reinit

### DIFF
--- a/cmd/elevator/main.go
+++ b/cmd/elevator/main.go
@@ -14,6 +14,7 @@ import (
 	network "github.com/Mosazghi/elevator-ttk4145/internal/net"
 	"github.com/Mosazghi/elevator-ttk4145/internal/orders"
 	statesync "github.com/Mosazghi/elevator-ttk4145/internal/statesync"
+	"github.com/Mosazghi/elevator-ttk4145/shared"
 	"github.com/lmittmann/tint"
 )
 
@@ -64,8 +65,9 @@ func main() {
 	triggerAction := make(chan controller.ControllerTriggerSrc, 3*cfg.Floors)
 	orderUpdateChan := make(chan statesync.Order, 10)
 	actionChan := make(chan any, 10)
+	recoveredCabCallChan := make(chan shared.Emtpy, 5)
 	wvChan := make(chan statesync.Worldview, 20)
-	wv := statesync.NewWorldView(cfg.Id, cfg.Floors, wvChan, orderUpdateChan, actionChan)
+	wv := statesync.NewWorldView(cfg.Id, cfg.Floors, wvChan, orderUpdateChan, recoveredCabCallChan)
 
 	ctrller := controller.NewController(wv, actionChan, triggerAction, orderUpdateChan)
 	go ctrller.Start()
@@ -80,7 +82,6 @@ func main() {
 		elev.OnInitBetweenFloors()
 		localElvevator.Behavior = elevator.BMoving
 		localElvevator.Direction = elevio.MDDown
-
 	}
 
 	localElvevator.CurrentFloor = 0
@@ -94,14 +95,15 @@ func main() {
 	// Sync all button lights with the current worldview state before entering the
 	// main event loop, so the elevator server matches any persisted/recovered calls.
 	{
-		localElev := wv.GetRemoteElevator()
+		elev.SetDoor(false)
 		hallCallStates := wv.GetAllHallCalls()
-		hallCallBools := make([][2]bool, cfg.Floors)
+		hallCallBools := make([][2]bool, wv.NumFloors)
 		for floor, pair := range hallCallStates {
 			hallCallBools[floor][0] = pair[statesync.HDDown].State != statesync.HSNone
 			hallCallBools[floor][1] = pair[statesync.HDUp].State != statesync.HSNone
 		}
-		elev.SetAllLights(cfg.Floors, localElev.CabCalls, hallCallBools)
+		elev.SetHallCallLights(wv.NumFloors, hallCallBools)
+
 	}
 
 	fsm := fsm.NewStateMachine(
@@ -111,6 +113,7 @@ func main() {
 		drvStop,
 		triggerAction,
 		actionChan,
+		recoveredCabCallChan,
 		&elev,
 		wv,
 	)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -76,7 +76,7 @@ func (ctrl *Controller) Start() {
 	for {
 		select {
 		case order := <-ctrl.hcLightChan:
-			ctrl.actionChan <- elevator.LightAction{ButtonType: shared.HallDirToButtonType(order.Dir), Floor: order.Floor, State: !order.Completed}
+			ctrl.actionChan <- elevator.LightAction{ButtonType: HallDirToButtonType(order.Dir), Floor: order.Floor, State: !order.Completed}
 		case <-ctrl.doorTimerChan:
 			ctrl.doorTimerChan = nil
 			ctrl.actionChan <- elevator.MoveAction{Behavior: elevator.BIdle, Direction: elevio.MDStop}
@@ -85,14 +85,21 @@ func (ctrl *Controller) Start() {
 			elev := ctrl.wv.GetRemoteElevator()
 			closestOrder := FetchClosestOrder(ctrl.wv)
 
+			slog.Info("behavior", "behavior", elev.Behavior)
 			switch elev.Behavior {
+
 			case elevator.BDoorOpen:
 				if closestOrder.AtFloor(elev.CurrentFloor) {
 					ctrl.clearAllOrdersAtFloor(elev.CurrentFloor)
-       }
+				}
 			case elevator.BMoving:
 				if closestOrder.Empty() {
 					ctrl.actionChan <- elevator.MoveAction{Behavior: elevator.BIdle, Direction: elevio.MDStop}
+					continue
+				}
+				slog.Info("Closest order", "direction", closestOrder.MotorDirection, "Floor", closestOrder.Floor)
+				if elev.Direction != closestOrder.MotorDirection && !closestOrder.AtFloor(elev.CurrentFloor) {
+					ctrl.actionChan <- elevator.MoveAction{Behavior: elevator.BMoving, Direction: closestOrder.MotorDirection}
 					continue
 				}
 
@@ -100,7 +107,9 @@ func (ctrl *Controller) Start() {
 					ctrl.OnFloorArrival()
 				}
 			case elevator.BIdle:
+				slog.Info("Closest order", "direction", closestOrder.MotorDirection, "Floor", closestOrder.Floor)
 				if closestOrder.Empty() {
+
 					continue
 				}
 
@@ -200,7 +209,7 @@ func FindClosestHallCall(wv *statesync.Worldview) CurrentOrder {
 			}
 
 			hallCallDirection = statesync.HallCallDir(direction)
-			orderType = shared.HallDirToButtonType(hallCallDirection)
+			orderType = HallDirToButtonType(hallCallDirection)
 
 			cost += int(math.Abs(float64(floor - localElevator.CurrentFloor)))
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -10,6 +10,7 @@ import (
 	elevio "github.com/Mosazghi/elevator-ttk4145/internal/hw"
 	"github.com/Mosazghi/elevator-ttk4145/internal/statesync"
 	"github.com/Mosazghi/elevator-ttk4145/shared/checksum"
+	"github.com/Mosazghi/elevator-ttk4145/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ func newTestCtx(t *testing.T) (wv *statesync.Worldview, wvChan chan statesync.Wo
 	t.Helper()
 	wvChan = make(chan statesync.Worldview, 10)
 	arriveAtFloorChan = make(chan struct{}, 10)
-	worldview := statesync.NewWorldView(1, 4, wvChan, make(chan statesync.Order, 10))
+	worldview := statesync.NewWorldView(1, 4, wvChan, make(chan statesync.Order, 10), make(chan shared.Emtpy))
 	elev := statesync.NewRemoteElevatorState(ID, NumFloors)
 	_ = worldview.SetLocalElevator(elev)
 
@@ -408,7 +409,7 @@ func newDoorTimerTestCtx(t *testing.T, floor int) (*Controller, chan any, chan C
 	t.Helper()
 	wvChan := make(chan statesync.Worldview, 10)
 	orderChan := make(chan statesync.Order, 10)
-	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan)
+	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan, make(chan shared.Emtpy))
 	elev := statesync.NewRemoteElevatorState(ID, NumFloors)
 	elev.CurrentFloor = floor
 	require.NoError(t, wv.SetLocalElevator(elev))
@@ -432,7 +433,7 @@ func newCtrlWithStart(t *testing.T, floor int, doorDuration time.Duration) (*Con
 	t.Helper()
 	wvChan := make(chan statesync.Worldview, 10)
 	orderChan := make(chan statesync.Order, 10)
-	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan)
+	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan, make(chan shared.Emtpy))
 	elev := statesync.NewRemoteElevatorState(ID, NumFloors)
 	elev.CurrentFloor = floor
 	require.NoError(t, wv.SetLocalElevator(elev))
@@ -550,7 +551,7 @@ func TestDoorTimer_RearmOnSecondArrival(t *testing.T) {
 func TestDoorTimer_ClearsAllOrdersAtFloor(t *testing.T) {
 	wvChan := make(chan statesync.Worldview, 10)
 	orderChan := make(chan statesync.Order, 10)
-	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan)
+	wv := statesync.NewWorldView(ID, NumFloors, wvChan, orderChan, make(chan shared.Emtpy))
 	elev := statesync.NewRemoteElevatorState(ID, NumFloors)
 	elev.CurrentFloor = 2
 	require.NoError(t, wv.SetLocalElevator(elev))

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,8 +1,8 @@
-package shared
+package controller
 
 import (
 	elevio "github.com/Mosazghi/elevator-ttk4145/internal/hw"
-	"github.com/Mosazghi/elevator-ttk4145/internal/statesync"
+	statesync "github.com/Mosazghi/elevator-ttk4145/internal/statesync"
 )
 
 // HallDirToButtonType maps statesync HallCallDir to the correct elevio ButtonType.

--- a/internal/elevator/local_state.go
+++ b/internal/elevator/local_state.go
@@ -137,10 +137,21 @@ func (e *ElevatorState) SetCurrentFloorLight(floor int) {
 // hallCalls[floor][1] = HallUp light (matches statesync.HDUp=1).
 // The caller is responsible for converting statesync types to [][2]bool before calling this.
 func (e *ElevatorState) SetAllLights(numFloors int, cabCalls []bool, hallCalls [][2]bool) {
+	e.SetCabCallLights(numFloors, cabCalls)
+	e.SetHallCallLights(numFloors, hallCalls)
+}
+// SetCabCallLights sets lights for all active cab calls
+func (e *ElevatorState) SetCabCallLights(numFloors int, cabCalls []bool) {
+	for floor := 0; floor < numFloors; floor ++{
+		e.io.SetButtonLamp(elevio.Cab, floor, cabCalls[floor])
+	}
+}
+
+// SetHallCallLights sets lights for all active hall calls
+func (e *ElevatorState) SetHallCallLights(numFloors int, hallCalls [][2]bool) {
 	for floor := 0; floor < numFloors; floor++ {
 		e.io.SetButtonLamp(elevio.HallDown, floor, hallCalls[floor][0])
 		e.io.SetButtonLamp(elevio.HallUp, floor, hallCalls[floor][1])
-		e.io.SetButtonLamp(elevio.Cab, floor, cabCalls[floor])
 	}
 }
 

--- a/internal/fsm/fsm.go
+++ b/internal/fsm/fsm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Mosazghi/elevator-ttk4145/internal/elevator"
 	elevio "github.com/Mosazghi/elevator-ttk4145/internal/hw"
 	"github.com/Mosazghi/elevator-ttk4145/internal/statesync"
+	"github.com/Mosazghi/elevator-ttk4145/shared"
 )
 
 type StateMachine struct {
@@ -17,8 +18,9 @@ type StateMachine struct {
 	drvObst    chan bool
 	drvStop    chan bool
 	// Internal channels
-	ctrlTriggerChan chan controller.ControllerTriggerSrc
-	ctrlActionChan  chan any
+	ctrlTriggerChan      chan controller.ControllerTriggerSrc
+	ctrlActionChan       chan any
+	recoveredCabCallChan chan shared.Emtpy
 
 	elev *elevator.ElevatorState
 	wv   *statesync.Worldview
@@ -31,18 +33,20 @@ func NewStateMachine(
 	drvStop chan bool,
 	ctrlTriggerChan chan controller.ControllerTriggerSrc,
 	ctrlActionChan chan any,
+	recoveredCabCallChan chan shared.Emtpy,
 	elev *elevator.ElevatorState,
 	wv *statesync.Worldview,
 ) *StateMachine {
 	return &StateMachine{
-		drvButtons:      drvButtons,
-		drvFloors:       drvFloors,
-		drvObst:         drvObst,
-		drvStop:         drvStop,
-		ctrlTriggerChan: ctrlTriggerChan,
-		ctrlActionChan:  ctrlActionChan,
-		elev:            elev,
-		wv:              wv,
+		drvButtons:           drvButtons,
+		drvFloors:            drvFloors,
+		drvObst:              drvObst,
+		drvStop:              drvStop,
+		ctrlTriggerChan:      ctrlTriggerChan,
+		ctrlActionChan:       ctrlActionChan,
+		recoveredCabCallChan: recoveredCabCallChan,
+		elev:                 elev,
+		wv:                   wv,
 	}
 }
 
@@ -70,6 +74,12 @@ func (sm *StateMachine) Run() {
 			sm.elev.SetCurrentFloorLight(floor)
 			slog.Debug("[arriveAtFloor] trigger")
 			sm.ctrlTriggerChan <- controller.CTSFArrivalFloor
+
+		case <-sm.recoveredCabCallChan:
+			localElev := sm.wv.GetRemoteElevator()
+			sm.elev.SetCabCallLights(sm.wv.NumFloors, localElev.CabCalls)
+
+			sm.ctrlTriggerChan <- controller.CTSOrderUpdate
 
 		case action := <-sm.ctrlActionChan:
 			// slog.Debug("[StateMachine] Received action", "type", fmt.Sprintf("%T", action), "value", action)

--- a/internal/orders/orders_handler.go
+++ b/internal/orders/orders_handler.go
@@ -76,6 +76,10 @@ func CalculateCost(wv *statesync.Worldview, floor int, dir statesync.HallCallDir
 	winner := ElevatorCost{-1, wv.NumFloors + 1, 100}
 
 	for id, elev := range wv.ElevatorStates {
+		if !elev.Alive {
+			continue
+		}
+
 		currentElevatorCost := ElevatorCost{-1, wv.NumFloors + 1, 0}
 		isObstructed := elev.IsObstructed
 

--- a/internal/statesync/sync.go
+++ b/internal/statesync/sync.go
@@ -6,10 +6,8 @@ import (
 	"slices"
 	"sync"
 	"time"
-
-	"github.com/Mosazghi/elevator-ttk4145/internal/elevator"
-	elevio "github.com/Mosazghi/elevator-ttk4145/internal/hw"
 	network "github.com/Mosazghi/elevator-ttk4145/internal/net"
+	. "github.com/Mosazghi/elevator-ttk4145/shared"
 	"github.com/Mosazghi/elevator-ttk4145/shared/checksum"
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -26,29 +24,29 @@ type Message struct {
 }
 
 type Worldview struct {
-	LocalID            int                          `json:"local_id"`
-	ElevatorStates     map[int]*RemoteElevatorState `json:"elevator_states"`
-	HallCalls          [][2]HallCallPairState       `json:"hall_calls"`
-	NumFloors          int                          `json:"num_floors"`
-	wvChan             chan Worldview
-	orderUpdateChan    chan Order
-	actionChan 		   chan any
-	hasFetchedCabCalls bool
-	mu                 *sync.RWMutex
+	LocalID              int                          `json:"local_id"`
+	ElevatorStates       map[int]*RemoteElevatorState `json:"elevator_states"`
+	HallCalls            [][2]HallCallPairState       `json:"hall_calls"`
+	NumFloors            int                          `json:"num_floors"`
+	wvChan               chan Worldview
+	orderUpdateChan      chan Order
+	recoveredCabCallChan chan Emtpy
+	hasFetchedCabCalls   bool
+	mu                   *sync.RWMutex
 }
 
 // NewWorldView creates a new instance
-func NewWorldView(localID, numFloors int, wvChan chan Worldview, orderUpdateChan chan Order, actionChan chan any) *Worldview {
+func NewWorldView(localID, numFloors int, wvChan chan Worldview, orderUpdateChan chan Order, recoveredCabCallChan chan Emtpy) *Worldview {
 	wv := &Worldview{
-		LocalID:            localID,
-		ElevatorStates:     make(map[int]*RemoteElevatorState),
-		HallCalls:          make([][2]HallCallPairState, numFloors),
-		NumFloors:          numFloors,
-		wvChan:             wvChan,
-		orderUpdateChan:    orderUpdateChan,
-		hasFetchedCabCalls: false,
-		actionChan: 		actionChan,
-		mu:                 &sync.RWMutex{},
+		LocalID:             localID,
+		ElevatorStates:      make(map[int]*RemoteElevatorState),
+		HallCalls:           make([][2]HallCallPairState, numFloors),
+		NumFloors:           numFloors,
+		wvChan:              wvChan,
+		orderUpdateChan:     orderUpdateChan,
+		hasFetchedCabCalls:  false,
+		recoveredCabCallChan: recoveredCabCallChan,
+		mu:                  &sync.RWMutex{},
 	}
 
 	for i := range wv.HallCalls {
@@ -168,7 +166,7 @@ func (wv *Worldview) StartSyncing(txChan chan<- network.UDPMessage, rxChan <-cha
 
 // FetchCabCallsOnReconnect ORs the local Cab Calls with those of the peer
 // and signals cab lights to be turned back on when applicable.
-// 
+//
 // Must be called with lock held.
 func (wv *Worldview) FetchCabCallsOnReconnect(other *Worldview) {
 
@@ -176,19 +174,19 @@ func (wv *Worldview) FetchCabCallsOnReconnect(other *Worldview) {
 	myView := wv.ElevatorStates[wv.LocalID]
 
 	for floor, peerCabCallValue := range peerView.CabCalls {
-		prevView := myView.CabCalls[floor]
+		//prevView := myView.CabCalls[floor]
 		myView.CabCalls[floor] = myView.CabCalls[floor] || peerCabCallValue
 
-		if !prevView && myView.CabCalls[floor] {
-			wv.actionChan <- elevator.LightAction{
-				ButtonType: elevio.Cab,
-				Floor:		floor,
-				State: 		true,
-			}
-		}
+		// if !prevView && myView.CabCalls[floor] {
+		// 	wv.actionChan <- elevator.LightAction{
+		// 		ButtonType: elevio.Cab,
+		// 		Floor:      floor,
+		// 		State:      true,
+		// 	}
+		// }
 
 	}
-
+	wv.recoveredCabCallChan <- Emtpy{}
 	slog.Info("[Merge] Cab calls recovered from peer", "cabCalls", myView.CabCalls)
 }
 

--- a/internal/statesync/sync_test.go
+++ b/internal/statesync/sync_test.go
@@ -10,6 +10,7 @@ import (
 	elevio "github.com/Mosazghi/elevator-ttk4145/internal/hw"
 	network "github.com/Mosazghi/elevator-ttk4145/internal/net"
 	"github.com/Mosazghi/elevator-ttk4145/shared/checksum"
+	"github.com/Mosazghi/elevator-ttk4145/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack/v5"
@@ -17,7 +18,7 @@ import (
 
 // Easier to create test worldviews with this helper function
 func NewTestWorldView(t *testing.T, localID, numFloors int) *Worldview {
-	return NewWorldView(localID, numFloors, make(chan Worldview, 10), make(chan Order, 10), make(chan any, 10))
+	return NewWorldView(localID, numFloors, make(chan Worldview, 10), make(chan Order, 10), make(chan shared.Emtpy, 10))
 }
 
 // Merge with different number of floors should fail

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,0 +1,3 @@
+package shared
+
+type Emtpy struct{}


### PR DESCRIPTION
FetchCabCallsOnReconnect now signals fsm through a new local wv channel. fsm then signals the controller to update orders, which in turn toggles cab call lights. 

Fixed bug where the elevator would run with the door open upon initiation